### PR TITLE
param added

### DIFF
--- a/code/__DEFINES/href_commands.dm
+++ b/code/__DEFINES/href_commands.dm
@@ -1,14 +1,29 @@
 // This is not technically a macro, but for the purpose of this, these are here
-#define DEFINE_HREF_COMMAND(_thing) /datum/hrefcmd/var/_thing = #_thing;/datum/hrefcmd/print/_thing = "hrefcmd="+#_thing;
+#define DEFINE_HREF_COMMAND(_command) \
+/datum/hrefcmd/##_command; \
+/datum/hrefcmd/var/datum/hrefcmd/##_command/##_command = #_command; \
+/datum/hrefcmd/print/##_command = "hrefcmd="+#_command;
+#define DEFINE_HREF_PARAM(_command, _param_name) \
+/datum/hrefcmd/param/##_command = /datum/hrefcmd/##_command; \
+/datum/hrefcmd/##_command/var/##_param_name = #_param_name;
+
 
 // list of actual href commands
 DEFINE_HREF_COMMAND(reload_tguipanel)
+
 DEFINE_HREF_COMMAND(admin_pm)
+DEFINE_HREF_PARAM(admin_pm, msg_target)
+
 DEFINE_HREF_COMMAND(mentor_msg)
+DEFINE_HREF_PARAM(mentor_msg, msg_target)
+
 DEFINE_HREF_COMMAND(commandbar_typing)
+
 DEFINE_HREF_COMMAND(openLink)
+DEFINE_HREF_PARAM(openLink, link)
 
 DEFINE_HREF_COMMAND(var_edit)
+DEFINE_HREF_PARAM(var_edit, Vars)
 
 #undef DEFINE_HREF_COMMAND
 

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -275,7 +275,7 @@
 	rustg_log_close_all()
 
 /* Helper procs for building detailed log lines */
-/proc/key_name(whom, include_link = null, include_name = TRUE, hrefcmd = /datum/hrefcmd/print::admin_pm+";msg_target")
+/proc/key_name(whom, include_link = null, include_name = TRUE, hrefcmd = /datum/hrefcmd/print::admin_pm+";"+/datum/hrefcmd/param::admin_pm::msg_target)
 	var/mob/M
 	var/client/C
 	var/key

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -352,7 +352,7 @@
 
 	if(GLOB.round_id)
 		var/statspage = CONFIG_GET(string/roundstatsurl)
-		var/info = statspage ? "<a href='byond://?[/datum/hrefcmd/print::openLink]&link=[rustg_url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
+		var/info = statspage ? "<a href='byond://?[/datum/hrefcmd/print::openLink];[/datum/hrefcmd/param::openLink::link]=[rustg_url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
 		parts += "[GLOB.TAB]Round ID: <b>[info]</b>"
 	parts += "[GLOB.TAB]Shift Duration: <B>[DisplayTimeText(world.time - SSticker.round_start_time)]</B>"
 	parts += "[GLOB.TAB]Station Integrity: <B>[mode.station_was_nuked ? span_redtext("Destroyed") : "[popcount["station_integrity"]]%"]</B>"

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -221,7 +221,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 /datum/game_mode/dynamic/admin_panel()
 	var/list/dat = list()
-	dat += "Dynamic Mode <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[FAST_REF(src)]'>VV</a> <a href='byond://?src=[FAST_REF(src)];[HrefToken()]'>Refresh</a><BR>"
+	dat += "Dynamic Mode <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[FAST_REF(src)]'>VV</a> <a href='byond://?src=[FAST_REF(src)];[HrefToken()]'>Refresh</a><BR>"
 	dat += "Threat Level: <b>[threat_level]</b><br/>"
 	dat += "Budgets (Roundstart/Midrounds): <b>[initial_round_start_budget]/[threat_level - initial_round_start_budget]</b><br/>"
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -79,14 +79,14 @@
 
 
 	body += "<br>"
-	body += "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(M)]'>VV</a> "
+	body += "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(M)]'>VV</a> "
 	if(M.mind)
 		body += "<a href='byond://?_src_=holder;[HrefToken()];traitor=[REF(M)]'>TP</a> "
 	else
 		body += "<a href='byond://?_src_=holder;[HrefToken()];initmind=[REF(M)]'>Init Mind</a> "
 	if (iscyborg(M))
 		body += "<a href='byond://?_src_=holder;[HrefToken()];borgpanel=[REF(M)]'>BP</a> "
-	body += "<a href='byond://?[/datum/hrefcmd/print::admin_pm];msg_target=[M.ckey]'>PM</a> "
+	body += "<a href='byond://?[/datum/hrefcmd/print::admin_pm];[/datum/hrefcmd/param::admin_pm::msg_target]=[M.ckey]'>PM</a> "
 	body += "<a href='byond://?_src_=holder;[HrefToken()];subtlemessage=[REF(M)]'>SM</a> "
 	if (ishuman(M) && M.mind)
 		body += "<a href='byond://?_src_=holder;[HrefToken()];HeadsetMessage=[REF(M)]'>HM</a> "

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -7,7 +7,7 @@
 	if(owner.current)
 		return "<a href='byond://?_src_=holder;[HrefToken()];adminplayeropts=[REF(owner.current)]'>[owner.current.real_name]</a> "
 	else
-		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(owner)]'>[owner.name]</a> "
+		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(owner)]'>[owner.name]</a> "
 
 //Whatever interesting things happened to the antag admins should know about
 //Include additional information about antag in this part
@@ -28,7 +28,7 @@
 	if(!owner)
 		return
 	var/list/parts = list()
-	parts += "<a href='byond://?[/datum/hrefcmd/print::admin_pm];msg_target=[ckey(owner.key)]'>PM</a>"
+	parts += "<a href='byond://?[/datum/hrefcmd/print::admin_pm];[/datum/hrefcmd/param::admin_pm::msg_target]=[ckey(owner.key)]'>PM</a>"
 	if(owner.current) //There's body to follow
 		parts += "<a href='byond://?_src_=holder;[HrefToken()];adminplayerobservefollow=[REF(owner.current)]'>FLW</a>"
 	else

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -701,7 +701,7 @@ GLOBAL_LIST_INIT(sdql2_queries, GLOB.sdql2_queries || list())
 
 /datum/SDQL2_query/proc/SDQL_print(object, list/text_list, print_nulls = TRUE)
 	if(is_proper_datum(object))
-		text_list += "<A HREF='BYOND://?[/datum/hrefcmd/print::var_edit];[HrefToken(TRUE)];Vars=[REF(object)]'>[REF(object)]</A> : [object]"
+		text_list += "<A HREF='BYOND://?[/datum/hrefcmd/print::var_edit];[HrefToken(TRUE)];[/datum/hrefcmd/param::var_edit::Vars]=[REF(object)]'>[REF(object)]</A> : [object]"
 		if(istype(object, /atom))
 			var/atom/A = object
 			var/turf/T = A.loc

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -325,7 +325,7 @@
 	msg = emoji_parse(msg)
 
 	to_chat(C, "<font color='red' size='4'><b>-- Administrator private message --</b></font>", type = MESSAGE_TYPE_ADMINPM)
-	to_chat(C, span_adminsay("Admin PM from-<b><a href='byond://?[/datum/hrefcmd/print::admin_pm];msg_target=[stealthkey]'>[adminname]</A></b>: [msg]"), allow_linkify = TRUE, type = MESSAGE_TYPE_ADMINPM)
+	to_chat(C, span_adminsay("Admin PM from-<b><a href='byond://?[/datum/hrefcmd/print::admin_pm];[/datum/hrefcmd/param::admin_pm::msg_target]=[stealthkey]'>[adminname]</A></b>: [msg]"), allow_linkify = TRUE, type = MESSAGE_TYPE_ADMINPM)
 	to_chat(C, span_adminsay("<i>Click on the administrator's name to reply.</i>"), type = MESSAGE_TYPE_ADMINPM)
 
 	admin_ticket_log(C, msg, adminname, null, "cyan", isSenderAdmin = TRUE, safeSenderLogged = TRUE)

--- a/code/modules/admin/view_variables/debug_variables.dm
+++ b/code/modules/admin/view_variables/debug_variables.dm
@@ -55,10 +55,10 @@
 	var/name_part = VV_HTML_ENCODE(name)
 	if(level > 0 || islist(owner)) //handling keys in assoc lists
 		if(istype(name,/datum))
-			name_part = "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(name)]'>[VV_HTML_ENCODE(name)] [REF(name)]</a>"
+			name_part = "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(name)]'>[VV_HTML_ENCODE(name)] [REF(name)]</a>"
 		else if(islist(name))
 			var/list/list_value = name
-			name_part = "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(name)]'> /list ([length(list_value)]) [REF(name)]</a>"
+			name_part = "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(name)]'> /list ([length(list_value)]) [REF(name)]</a>"
 
 	. = "[.][name_part] = "
 
@@ -91,11 +91,11 @@
 		#endif
 
 	if(isappearance(value)) // Reminder: Do not replace this into /image/debug_variable_value() proc. /appearance can't do that.
-		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(value)]'>/appearance ([span_value("[get_appearance_vv_summary_name(value)]")]) [REF(value)]</a>"
+		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(value)]'>/appearance ([span_value("[get_appearance_vv_summary_name(value)]")]) [REF(value)]</a>"
 
 	if(isimage(value))
 		var/image/image = value
-		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(value)]'>[image.type] ([span_value("[get_appearance_vv_summary_name(image)]")]) [REF(value)]</a>"
+		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(value)]'>[image.type] ([span_value("[get_appearance_vv_summary_name(image)]")]) [REF(value)]</a>"
 
 	// fun fact: there are two types of /filters. `/filters(/filters(), /filters(), ...)`
 	// isfilter() doesn't know if it's a parent filter(that has [/filters]s inside of itself), or a child filter
@@ -168,13 +168,13 @@
 
 /datum/proc/debug_variable_value(name, level, datum/owner, sanitize, display_flags)
 	if("[src]" != "[type]") // If we have a name var, let's use it.
-		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(src)]'>[src] [type] [REF(src)]</a>"
+		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(src)]'>[src] [type] [REF(src)]</a>"
 	else
-		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(src)]'>[type] [REF(src)]</a>"
+		return "<a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(src)]'>[type] [REF(src)]</a>"
 
 /datum/weakref/debug_variable_value(name, level, datum/owner, sanitize, display_flags)
 	. = ..()
-	return "[.] <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[reference]'>(Resolve)</a>"
+	return "[.] <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[reference]'>(Resolve)</a>"
 
 /matrix/debug_variable_value(name, level, datum/owner, sanitize, display_flags)
 	return {"<span class='value'>

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -36,7 +36,7 @@
 		if(!target)
 			to_chat(usr, span_warning("The object you tried to expose to [C] no longer exists (nulled or hard-deled)"))
 			return
-		message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='byond://?[/datum/hrefcmd/print::var_edit];Vars=[REF(target)]'>VV window</a>")
+		message_admins("[key_name_admin(usr)] Showed [key_name_admin(C)] a <a href='byond://?[/datum/hrefcmd/print::var_edit];[/datum/hrefcmd/param::var_edit::Vars]=[REF(target)]'>VV window</a>")
 		log_admin("Admin [key_name(usr)] Showed [key_name(C)] a VV window of a [target]")
 		to_chat(C, "[holder.fakekey ? "an Administrator" : "[usr.client.key]"] has granted you access to view a View Variables window")
 		C.debug_variables(target)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -439,13 +439,13 @@
 		var/mob/M = N.current
 		if(M)
 			heads_report += "<tr><td><a href='byond://?_src_=holder;[HrefToken()];adminplayeropts=[REF(M)]'>[M.real_name]</a>[M.client ? "" : " <i>(No Client)</i>"][M.stat == DEAD ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"
-			heads_report += "<td><A href='byond://?[/datum/hrefcmd/print::admin_pm];msg_target=[M.ckey]'>PM</A></td>"
+			heads_report += "<td><A href='byond://?[/datum/hrefcmd/print::admin_pm];[/datum/hrefcmd/param::admin_pm::msg_target]=[M.ckey]'>PM</A></td>"
 			heads_report += "<td><A href='byond://?_src_=holder;[HrefToken()];adminplayerobservefollow=[REF(M)]'>FLW</a></td>"
 			var/turf/mob_loc = get_turf(M)
 			heads_report += "<td>[mob_loc.loc]</td></tr>"
 		else
-			heads_report += "<tr><td><a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(N)]'>[N.name]([N.key])</a><i>Head body destroyed!</i></td>"
-			heads_report += "<td><A href='byond://?[/datum/hrefcmd/print::admin_pm];msg_target=[N.key]'>PM</A></td></tr>"
+			heads_report += "<tr><td><a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(N)]'>[N.name]([N.key])</a><i>Head body destroyed!</i></td>"
+			heads_report += "<td><A href='byond://?[/datum/hrefcmd/print::admin_pm];[/datum/hrefcmd/param::admin_pm::msg_target]=[N.key]'>PM</A></td></tr>"
 	heads_report += "</table>"
 	return common_part + heads_report
 

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -194,11 +194,11 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 	var/html = build_header(back_to, linear)
 	html += "[name]<div class='runtime'>[desc]</div>"
 	if (usr_ref)
-		html += "<br><b>usr</b>: <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[usr_ref]'>VV</a>"
+		html += "<br><b>usr</b>: <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[usr_ref]'>VV</a>"
 		html += " <a href='byond://?_src_=holder;[HrefToken()];adminplayeropts=[usr_ref]'>PP</a>"
 		html += " <a href='byond://?_src_=holder;[HrefToken()];adminplayerobservefollow=[usr_ref]'>Follow</a>"
 		if (istype(usr_loc))
-			html += "<br><b>usr.loc</b>: <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];Vars=[REF(usr_loc)]'>VV</a>"
+			html += "<br><b>usr.loc</b>: <a href='byond://?[/datum/hrefcmd/print::var_edit];[HrefToken()];[/datum/hrefcmd/param::var_edit::Vars]=[REF(usr_loc)]'>VV</a>"
 			html += " <a href='byond://?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[usr_loc.x];Y=[usr_loc.y];Z=[usr_loc.z]'>JMP</a>"
 
 	browse_to(user, html)

--- a/code/modules/mentor/mentorpm.dm
+++ b/code/modules/mentor/mentorpm.dm
@@ -125,7 +125,7 @@
 
 	if(key)
 		if(include_link)
-			. += "<a href='byond://?_src_=mentor;[/datum/hrefcmd/print::mentor_msg];;msg_target=[ckey];'>"
+			. += "<a href='byond://?_src_=mentor;[/datum/hrefcmd/print::mentor_msg];[/datum/hrefcmd/param::mentor_msg::msg_target]=[ckey];'>"
 		if(C && C.holder && C.holder.fakekey)
 			. += "Administrator"
 		else

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -57,7 +57,7 @@
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
 		var/message = "A [reaction_name] reaction has occurred in [ADMIN_VERBOSEJMP(T)]"
-		message += " (<A HREF='BYOND://?[/datum/hrefcmd/print::var_edit];Vars=[REF(A)]'>VV</A>)"
+		message += " (<A HREF='BYOND://?[/datum/hrefcmd/print::var_edit];[/datum/hrefcmd/param::var_edit::Vars]=[REF(A)]'>VV</A>)"
 
 		var/mob/M = get(A, /mob)
 		if(M)


### PR DESCRIPTION
`/datum/hrefcmd/param` is added
```DM
/datum/hrefcmd/print::var_edit
/datum/hrefcmd/param::var_edit::Vars
```
You can access the initial value by doing such
```DM
body += "<a href='byond://?[/datum/hrefcmd/print::admin_pm];[/datum/hrefcmd/param::admin_pm::msg_target]=[M.ckey]'>PM</a> "
```
These are defined as
```DM
DEFINE_HREF_COMMAND(admin_pm)
DEFINE_HREF_PARAM(admin_pm, msg_target)
```
If you attempt to define a PARAM without a COMMAND
```DM
DEFINE_HREF_PARAM(random_command, some_param)
```
The compiler rejects this because there is no `DEFINE_HREF_COMMAND(random_command)`

```DM
DEFINE_HREF_COMMAND(random_command)
DEFINE_HREF_PARAM(random_command, some_param)
```
This will compile properly